### PR TITLE
Adds necessary switch to Linux install

### DIFF
--- a/installing_helm.md
+++ b/installing_helm.md
@@ -2,7 +2,7 @@
 
 ## Using snap
 ```bash
-sudo snap install helm
+sudo snap install helm --classic
 ```
 
 ## Using binary package:


### PR DESCRIPTION
`--classic` was missing, necessary for current `snap` installs  